### PR TITLE
fix: made autonomous cloud init template optional. 

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -39,7 +39,7 @@ resource "oci_core_instance" "bastion" {
 
   metadata = {
     ssh_authorized_keys = (var.ssh_public_key != "") ? var.ssh_public_key : (var.ssh_public_key_path != "none") ? file(var.ssh_public_key_path) : ""
-    user_data           = data.cloudinit_config.bastion.rendered
+    user_data           = var.bastion_image_id == "Autonomous" ? data.cloudinit_config.bastion.rendered : null
   }
 
   shape = lookup(var.bastion_shape, "shape", "VM.Standard.E2.2")


### PR DESCRIPTION
It will only be used when Autonomous is chosen. Closes #48 

Signed-off-by: Ali Mukadam <ali.mukadam@oracle.com>