### PR TITLE
fix: Compartment AD listing, ignore lifecycle changes

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -34,7 +34,7 @@ resource "oci_core_instance" "bastion" {
 
   # prevent the bastion from destroying and recreating itself if the image ocid changes 
   lifecycle {
-    ignore_changes = [source_details[0].source_id]
+    ignore_changes = [freeform_tags, source_details[0].source_id]
   }
 
   metadata = {

--- a/datasources.tf
+++ b/datasources.tf
@@ -2,7 +2,7 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 data "oci_identity_availability_domain" "ad" {
-  compartment_id = var.tenancy_id
+  compartment_id = var.compartment_id
   ad_number      = var.availability_domain
 }
 

--- a/security.tf
+++ b/security.tf
@@ -26,5 +26,10 @@ resource "oci_core_security_list" "bastion" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [freeform_tags]
+  }
+
   vcn_id = var.vcn_id
 }

--- a/subnets.tf
+++ b/subnets.tf
@@ -11,4 +11,8 @@ resource "oci_core_subnet" "bastion" {
   route_table_id             = var.ig_route_id
   security_list_ids          = [oci_core_security_list.bastion.id]
   vcn_id                     = var.vcn_id
+
+  lifecycle {
+    ignore_changes = [freeform_tags]
+  }
 }


### PR DESCRIPTION
- Use specific compartment for AD listing in case different
- Ignore lifecycle changes for automatic tagging