### PR TITLE
fix: Ignore lifecycle changes, and use consistent fallback shape

### DIFF
--- a/compute.tf
+++ b/compute.tf
@@ -42,10 +42,10 @@ resource "oci_core_instance" "bastion" {
     user_data           = var.bastion_image_id == "Autonomous" ? data.cloudinit_config.bastion.rendered : null
   }
 
-  shape = lookup(var.bastion_shape, "shape", "VM.Standard.E2.2")
+  shape = local.shape
 
   dynamic "shape_config" {
-    for_each = length(regexall("Flex", lookup(var.bastion_shape, "shape", "VM.Standard.E3.Flex"))) > 0 ? [1] : []
+    for_each = length(regexall("Flex", local.shape)) > 0 ? [1] : []
     content {
       ocpus         = max(1, lookup(var.bastion_shape, "ocpus", 1))
       memory_in_gbs = (lookup(var.bastion_shape, "memory", 4) / lookup(var.bastion_shape, "ocpus", 1)) > 64 ? (lookup(var.bastion_shape, "ocpus", 1) * 4) : lookup(var.bastion_shape, "memory", 4)

--- a/compute.tf
+++ b/compute.tf
@@ -34,7 +34,7 @@ resource "oci_core_instance" "bastion" {
 
   # prevent the bastion from destroying and recreating itself if the image ocid changes 
   lifecycle {
-    ignore_changes = [freeform_tags, source_details[0].source_id]
+    ignore_changes = [availability_domain, defined_tags, freeform_tags, metadata, source_details[0].source_id]
   }
 
   metadata = {

--- a/locals.tf
+++ b/locals.tf
@@ -13,6 +13,9 @@ locals {
 
   bastion_image_id = var.bastion_image_id == "Autonomous" ? data.oci_core_images.autonomous_images.images.0.id : var.bastion_image_id
 
+  default_shape = "VM.Standard.E4.Flex"
+  shape = lookup(var.bastion_shape, "shape", local.default_shape)
+
   notification_template = base64gzip(
     templatefile("${path.module}/scripts/notification.template.sh",
       {


### PR DESCRIPTION
# Proposed changes

## Ignore lifecycle changes
* availability_domain
* defined_tags
* metadata

```
  # module.bastion[0].oci_core_instance.bastion must be replaced
-/+ resource "oci_core_instance" "bastion" {
      ~ availability_domain                 = "aaaa:US-ASHBURN-AD-1" -> (known after apply) # forces replacement
```

```
~ metadata                            = {
    - "ssh_authorized_keys" = <<-EOT
          ssh-rsa ...
      EOT
    - "user_data"           = "..."
  } -> (known after apply) # forces replacement
  ```

## Use consistent fallback shape

- Use the same value for shape and shape_config to determine whether Flex
- Use recent shape for both

# Testing
Repeated apply, manually changing tags on resources and overriding the value returned by `ad.name`:
```
terraform apply
Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

terraform apply
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```