### PR TITLE
feat: Support disabled DNS record assignment for bastion subnet

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,21 @@ All notable changes to this project are documented in this file.
 
 The format is based on {uri-changelog}[Keep a Changelog].
 
+= v3.1.4 (unreleased)
+* feat: Support disabled DNS record assignment for bastion subnet by @devoncrouse
+
+= v3.1.3 (October 7, 2022)
+* fix: Ignore lifecycle changes, and use consistent fallback shape by @devoncrouse in #51
+
+= v3.1.2 (October 5, 2022)
+* fix: Compartment AD listing, ignore lifecycle changes by @devoncrouse in #50
+
+= v3.1.1 (April 26, 2022)
+* fix: made autonomous cloud init template optional. by @hyder in #49
+
+= v3.1.0 (March 27, 2022)
+* fix: Provider changed from hashicorp/oci to oracle/oci by @karthicgit in #47
+
 = v3.0.0 (September 21, 2021)
 
 == New features

--- a/subnets.tf
+++ b/subnets.tf
@@ -1,11 +1,11 @@
-# Copyright 2019, 2021 Oracle Corporation and/or affiliates.  All rights reserved.
+# Copyright 2019, 2022 Oracle Corporation and/or affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 resource "oci_core_subnet" "bastion" {
   cidr_block                 = cidrsubnet(local.vcn_cidr, var.newbits, var.netnum)
   compartment_id             = var.compartment_id
   display_name               = var.label_prefix == "none" ? "bastion" : "${var.label_prefix}-bastion"
-  dns_label                  = "bastion"
+  dns_label                  = var.assign_dns ? "bastion" : null
   freeform_tags              = var.freeform_tags
   prohibit_public_ip_on_vnic = var.bastion_type == "public" ? false : true
   route_table_id             = var.ig_route_id

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, 2021 Oracle Corporation and/or affiliates.  All rights reserved.
+# Copyright (c) 2019, 2022 Oracle Corporation and/or affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # provider parameters
@@ -18,6 +18,12 @@ variable "label_prefix" {
   description = "a string that will be prepended to all resources"
   type        = string
   default     = "none"
+}
+
+variable "assign_dns" {
+  default     = true
+  description = "Whether to assign DNS records to created instances"
+  type        = bool
 }
 
 # network parameters


### PR DESCRIPTION
Allow disabling of bastion subnet DNS record assignment, e.g. in cases where DNS is disabled for the VCN.