### PR TITLE
feat: Support disabled DNS record assignment for bastion instance

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,8 +7,11 @@ All notable changes to this project are documented in this file.
 
 The format is based on {uri-changelog}[Keep a Changelog].
 
-= v3.1.4 (unreleased)
-* feat: Support disabled DNS record assignment for bastion subnet by @devoncrouse
+= v3.1.5 (December 1, 2022)
+* feat: Support disabled DNS record assignment for bastion instance by @devoncrouse in #53
+
+= v3.1.4 (December 1, 2022)
+* feat: Support disabled DNS record assignment for bastion subnet by @devoncrouse in #52
 
 = v3.1.3 (October 7, 2022)
 * fix: Ignore lifecycle changes, and use consistent fallback shape by @devoncrouse in #51

--- a/compute.tf
+++ b/compute.tf
@@ -1,4 +1,4 @@
-# Copyright 2019, 2021 Oracle Corporation and/or affiliates.  All rights reserved.
+# Copyright 2019, 2022 Oracle Corporation and/or affiliates.  All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/
 
 resource "oci_core_instance" "bastion" {
@@ -21,7 +21,7 @@ resource "oci_core_instance" "bastion" {
   create_vnic_details {
     assign_public_ip = var.bastion_type == "public" ? true : false
     display_name     = var.label_prefix == "none" ? "bastion-vnic" : "${var.label_prefix}-bastion-vnic"
-    hostname_label   = "bastion"
+    hostname_label   = var.assign_dns ? "bastion" : null
     subnet_id        = oci_core_subnet.bastion.id
   }
 


### PR DESCRIPTION
Allow disabling of bastion instance DNS record assignment, e.g. in cases where DNS is disabled for the VCN.